### PR TITLE
Add OLED display to ESP8266 Firebase logger

### DIFF
--- a/ESP/ESP8266/DHT11_Firebase/DHT11_Firebase.ino
+++ b/ESP/ESP8266/DHT11_Firebase/DHT11_Firebase.ino
@@ -1,0 +1,98 @@
+#include <ESP8266WiFi.h>
+#include <DHT.h>
+#include <FirebaseArduino.h>
+#include <Wire.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+
+#define DHTPIN 2          // D4 on NodeMCU boards
+#define DHTTYPE DHT11
+
+// Replace with your network credentials and Firebase settings
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_WIFI_PASSWORD";
+const char* firebaseHost = "YOUR_FIREBASE_HOST"; // e.g. your-project.firebaseio.com
+const char* firebaseAuth = "YOUR_DATABASE_SECRET";
+
+DHT dht(DHTPIN, DHTTYPE);
+
+#define SCREEN_WIDTH 128
+#define SCREEN_HEIGHT 64
+#define OLED_RESET -1
+Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
+
+void setup() {
+  Serial.begin(115200);
+  delay(100);
+
+  dht.begin();
+
+  if (!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
+    Serial.println("SSD1306 allocation failed");
+    for (;;) {}
+  }
+  display.clearDisplay();
+  display.setTextSize(1);
+  display.setTextColor(SSD1306_WHITE);
+  display.setCursor(0, 0);
+  display.println("Connecting...");
+  display.display();
+
+  WiFi.begin(ssid, password);
+  Serial.print("Connecting to WiFi");
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println();
+  Serial.print("Connected, IP address: ");
+  Serial.println(WiFi.localIP());
+
+  display.clearDisplay();
+  display.setCursor(0, 0);
+  display.println("WiFi connected");
+  display.display();
+
+  Firebase.begin(firebaseHost, firebaseAuth);
+}
+
+void loop() {
+  float h = dht.readHumidity();
+  float t = dht.readTemperature();
+  if (isnan(h) || isnan(t)) {
+    Serial.println("Failed to read from DHT sensor!");
+    return;
+  }
+
+  Serial.print("Temperature: ");
+  Serial.print(t);
+  Serial.print(" °C, Humidity: ");
+  Serial.print(h);
+  Serial.println(" %");
+
+  display.clearDisplay();
+  display.setCursor(0, 0);
+  display.print("Temp: ");
+  display.print(t);
+  display.println(" C");
+  display.print("Hum:  ");
+  display.print(h);
+  display.println(" %");
+  display.display();
+
+  Firebase.setFloat("/dht11/temperature", t);
+  if (Firebase.failed()) {
+    Serial.print("setFloat failed: ");
+    Serial.println(Firebase.error());
+    return;
+  }
+
+  Firebase.setFloat("/dht11/humidity", h);
+  if (Firebase.failed()) {
+    Serial.print("setFloat failed: ");
+    Serial.println(Firebase.error());
+    return;
+  }
+
+  delay(5000); // send data every 5 seconds
+}

--- a/ESP/ESP8266/DHT11_Firebase/README.md
+++ b/ESP/ESP8266/DHT11_Firebase/README.md
@@ -1,0 +1,35 @@
+# DHT11 Firebase Logger (ESP8266)
+
+This sketch demonstrates how to read temperature and humidity data from a DHT11 sensor, display the values on a small OLED screen and upload them to Firebase using an ESP8266 board. It is intended for the Arduino IDE.
+
+## Required libraries
+
+- **ESP8266WiFi** (included with ESP8266 core)
+- **DHT sensor library** by Adafruit
+- **FirebaseArduino** library
+- **Adafruit SSD1306** and **Adafruit GFX** libraries
+
+Install these libraries through the Arduino Library Manager before compiling the example.
+
+## Wiring
+
+- DHT11 data pin -> ESP8266 GPIO2 (D4 on NodeMCU)
+- DHT11 VCC pin -> 3.3V
+- DHT11 GND pin -> GND
+- OLED SDA -> ESP8266 GPIO4 (D2 on NodeMCU)
+- OLED SCL -> ESP8266 GPIO5 (D1 on NodeMCU)
+
+## Configuration
+
+Replace the placeholders in `DHT11_Firebase.ino` with your WiFi credentials and Firebase settings:
+
+```cpp
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_WIFI_PASSWORD";
+const char* firebaseHost = "YOUR_FIREBASE_HOST"; // e.g. your-project.firebaseio.com
+const char* firebaseAuth = "YOUR_DATABASE_SECRET";
+```
+
+## Running the example
+
+Upload the sketch to your ESP8266 board. Once connected to WiFi, the device will display the current readings on the OLED and periodically send temperature and humidity values to the `dht11` path in your Firebase database.

--- a/ESP/ESP8266/README.md
+++ b/ESP/ESP8266/README.md
@@ -1,3 +1,5 @@
 # ESP8266
 
-Placeholder for ESP8266-specific examples.
+Example sketches for the ESP8266 platform.
+
+- **DHT11_Firebase** – Logs temperature and humidity data from a DHT11 sensor to Firebase and shows the readings on an OLED display.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository collects various embedded systems projects. Directories are orga
 
 - **ARM/** – Projects for ARM Cortex boards. The `Nucleo_64` folder contains a sample STM32F401RE project (`F401RE_MAX30102_HR_SPO2_1`).
 - **AVR/** – Placeholder for projects targeting AVR microcontrollers.
-- **ESP/** – Directories for ESP32 and ESP8266 code.
+- **ESP/** – Directories for ESP32 and ESP8266 code. The ESP8266 folder now includes a Firebase logging example that also uses an OLED display.
 
 ## Building projects
 
@@ -14,6 +14,4 @@ This repository collects various embedded systems projects. Directories are orga
 The project under `ARM/Nucleo_64/STM32F401RE/F401RE_MAX30102_HR_SPO2_1` was created with STM32CubeIDE. To build it you can either open the directory in STM32CubeIDE or run `make` inside the `Debug` subdirectory if the ARM GCC toolchain is installed.
 
 ### AVR and ESP
-These folders currently contain no code but serve as placeholders for future projects.
-
-
+These folders contain example sketches that can be built with the Arduino IDE.


### PR DESCRIPTION
## Summary
- extend `DHT11_Firebase` example to drive an OLED via Adafruit SSD1306
- document additional libraries and wiring details
- mention OLED in ESP8266 README and repository README

## Testing
- `make -C ARM/Nucleo_64/STM32F401RE/F401RE_MAX30102_HR_SPO2_1/Debug` *(fails: multiple target patterns)*

------
https://chatgpt.com/codex/tasks/task_e_6888fe000dfc8331933449c373f61e12