### PR TITLE
Add UART2 initialization message

### DIFF
--- a/ARM/Nucleo_64/STM32F401RE/F401RE_MAX30102_HR_SPO2_1/Core/Src/main.c
+++ b/ARM/Nucleo_64/STM32F401RE/F401RE_MAX30102_HR_SPO2_1/Core/Src/main.c
@@ -44,6 +44,12 @@ int __io_putchar(int ch)
     return ch;
 }
 
+// Convenience helper for sending strings over UART2
+void UART2_SendString(const char *str)
+{
+    HAL_UART_Transmit(&huart2, (uint8_t *)str, strlen(str), HAL_MAX_DELAY);
+}
+
 /* USER CODE END 0 */
 
 /**
@@ -76,6 +82,9 @@ int main(void)
   MX_GPIO_Init();
   MX_I2C1_Init();
   MX_USART2_UART_Init();
+
+  // Indicate that UART2 is working
+  UART2_SendString("UART2 initialized\r\n");
 
   /* USER CODE BEGIN 2 */
 


### PR DESCRIPTION
## Summary
- send a simple debug string over UART2 when the peripherals are initialized
- add a helper function to print strings to UART2

## Testing
- `make -C 'ARM/Nucleo_64/STM32F401RE/F401RE_MAX30102_HR_SPO2_1/Debug'` *(fails: multiple target patterns)*

------
https://chatgpt.com/codex/tasks/task_e_68899def4f148331b3c99453743f8a49